### PR TITLE
Extract UI and API strings into constants

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,70 +1,69 @@
 import { Plugin, MarkdownView, Notice, requestUrl } from "obsidian";
 import type { MyIPResponse } from "./src/types";
+import { API, UI } from "./src/constants";
 
 export default class MyIPPlugin extends Plugin {
   async onload() {
     this.addCommand({
       id: "insert-ip-info-inline",
-      name: "Insert IP Info at Cursor",
+      name: UI.CMD_INSERT_IP_NAME,
       callback: async () => {
         try {
-          // Use requestUrl which provides better error handling
           const response = await requestUrl({
-            url: "https://api.myip.com",
+            url: API.MYIP_URL,
             method: "GET",
-            throw: false, // Don't throw on non-2xx, we'll handle it
+            throw: false,
           });
 
-          // Check for HTTP errors
           if (response.status < 200 || response.status >= 300) {
-            new Notice(`IP service returned an error (HTTP ${response.status}).`);
+            new Notice(UI.NOTICE_HTTP_ERROR(response.status));
             console.error("HTTP error:", response.status, response.text);
             return;
           }
 
-          // Parse and validate response
           let data: MyIPResponse;
           try {
             data = JSON.parse(response.text);
           } catch (parseError) {
-            new Notice("Failed to parse IP service response.");
+            new Notice(UI.NOTICE_PARSE_ERROR);
             console.error("JSON parse error:", parseError);
             return;
           }
 
-          // Validate required fields exist
           if (!data.ip || !data.country || !data.cc) {
-            new Notice("IP service returned incomplete data.");
+            new Notice(UI.NOTICE_INCOMPLETE_DATA);
             console.error("Incomplete response:", data);
             return;
           }
 
           const html = `
 <div class="ip-info-box">
-  <div><strong>IP Address:</strong> ${data.ip}</div>
-  <div><strong>Country:</strong> ${data.country} (${data.cc})</div>
+  <div><strong>${UI.LABEL_IP}</strong> ${data.ip}</div>
+  <div><strong>${UI.LABEL_COUNTRY}</strong> ${data.country} (${data.cc})</div>
 </div>
           `.trim();
 
           const mdView = this.app.workspace.getActiveViewOfType(MarkdownView);
           if (mdView && mdView.editor) {
             mdView.editor.replaceSelection(html);
-            new Notice("IP info inserted.");
+            new Notice(UI.NOTICE_IP_INSERTED);
           } else {
-            new Notice("No active Markdown editor found.");
+            new Notice(UI.NOTICE_NO_MD_EDITOR);
           }
         } catch (err) {
-          // Handle network/connection errors
           console.error("Failed to fetch IP info:", err);
-          
+
           if (err instanceof Error) {
-            if (err.message.includes("net::ERR") || err.message.includes("Failed to fetch")) {
-              new Notice("Network error: Unable to reach IP service. Check your internet connection.");
+            if (
+              err.message.includes("net::ERR") ||
+              err.message.includes("Failed to fetch")
+            ) {
+              new Notice(UI.NOTICE_NETWORK_ERROR);
             } else {
-              new Notice(`Failed to fetch IP info: ${err.message}`);
+              new Notice(UI.NOTICE_FETCH_ERROR(err.message));
             }
           } else {
-            new Notice("An unexpected error occurred while fetching IP info.");
+            new Notice(UI.NOTICE_UNEXPECTED_ERROR);
           }
         }
       },

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,23 @@
+export const API = {
+  MYIP_URL: "https://api.myip.com",
+} as const;
+
+export const UI = {
+  CMD_INSERT_IP_NAME: "Insert IP Info at Cursor",
+  NOTICE_IP_INSERTED: "IP info inserted.",
+  NOTICE_NO_MD_EDITOR: "No active Markdown editor found.",
+
+  NOTICE_HTTP_ERROR: (status: number) =>
+    `IP service returned an error (HTTP ${status}).`,
+  NOTICE_PARSE_ERROR: "Failed to parse IP service response.",
+  NOTICE_INCOMPLETE_DATA: "IP service returned incomplete data.",
+
+  NOTICE_NETWORK_ERROR:
+    "Network error: Unable to reach IP service. Check your internet connection.",
+  NOTICE_UNEXPECTED_ERROR:
+    "An unexpected error occurred while fetching IP info.",
+  NOTICE_FETCH_ERROR: (msg: string) => `Failed to fetch IP info: ${msg}`,
+
+  LABEL_IP: "IP Address:",
+  LABEL_COUNTRY: "Country:",
+} as const;


### PR DESCRIPTION
Add src/constants.ts exporting API and UI constants (URLs, labels, and notice message builders) and update main.ts to use these constants. Replace hardcoded strings and URL with API.MYIP_URL and UI.* entries, consolidate notice messages and minor error-handling/message formatting changes. This is a refactor to centralize UI text and configuration without changing core plugin behavior.

fixes #7 